### PR TITLE
Handle trailing slashes in Spotify URLs

### DIFF
--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.metadata_service import MetadataService
+
+
+def test_extract_id_from_url_handles_trailing_slash_and_query():
+    service = MetadataService(spotify_client=None)
+    base_url = "https://open.spotify.com/album/"
+    assert service._extract_id_from_url(base_url + "12345") == "12345"
+    assert service._extract_id_from_url(base_url + "12345/") == "12345"
+    assert service._extract_id_from_url(base_url + "12345/?si=abc") == "12345"
+
+
+def test_get_item_type_case_insensitive():
+    service = MetadataService(spotify_client=None)
+    assert service._get_item_type("https://open.spotify.com/ALBUM/12345") == "album"
+    assert service._get_item_type("https://open.spotify.com/Track/12345") == "track"
+    assert service._get_item_type("https://open.spotify.com/PLAYLIST/12345") == "playlist"


### PR DESCRIPTION
## Summary
- Parse Spotify URLs more robustly, handling trailing slashes and query strings
- Make item type detection case-insensitive
- Test metadata service URL parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc62a7e8c832b8ca6d9b7876b8602