### PR TITLE
Assign ProgressHandler after Downloader initialization

### DIFF
--- a/src/download_service.py
+++ b/src/download_service.py
@@ -54,7 +54,8 @@ class AudioCoverDownloadService:
             format=self.spotdl_format,
             overwrite="skip",
         )
-        downloader = Downloader(options, progress_handler=progress_handler)
+        downloader = Downloader(options)
+        downloader.progress_handler = progress_handler
 
         try:
             downloader.download([spotify_link])  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- instantiate `Downloader` without `progress_handler` and attach handler afterwards

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c037db053c832baa7d68b77a03b81d