### PR TITLE
Use existing SpotDL progress handler

### DIFF
--- a/src/download_service.py
+++ b/src/download_service.py
@@ -31,7 +31,6 @@ class AudioCoverDownloadService:
 
         try:
             from spotdl.download.downloader import Downloader, DownloaderOptions
-            from spotdl.download.progress_handler import ProgressHandler
         except Exception as exc:
             logger.error("Failed to import SpotDL API: %s", exc)
             return False
@@ -47,7 +46,6 @@ class AudioCoverDownloadService:
             except Exception:
                 pass
 
-        progress_handler = ProgressHandler(update_callback=_update)
         options = DownloaderOptions(
             audio_providers=[self.spotdl_audio_source],
             output=output_template,
@@ -55,7 +53,8 @@ class AudioCoverDownloadService:
             overwrite="skip",
         )
         downloader = Downloader(options)
-        downloader.progress_handler = progress_handler
+        if downloader.progress_handler:
+            downloader.progress_handler.update_callback = _update
 
         try:
             downloader.download([spotify_link])  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- Simplify audio download progress tracking by using `Downloader`'s built-in progress handler
- Remove redundant `ProgressHandler` instantiation

## Testing
- `pytest -q`
- `python -m py_compile src/download_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68c03af76908832b81781370e7abadab