### PR TITLE
Add playlist and album support to download service

### DIFF
--- a/src/spotify_content_downloader.py
+++ b/src/spotify_content_downloader.py
@@ -107,6 +107,7 @@ class SpotifyContentDownloader:
             spotify_link,
             item_specific_output_dir,
             title_name,  # Pass item_title for output formatting
+            item_type=item_type,
             progress_callback=progress_cb,
         )
         if not audio_download_success:


### PR DESCRIPTION
## Summary
- extend download service to detect item type and handle playlist/album downloads
- ensure multi-song downloads succeed only when all tracks complete
- propagate resolved item type from SpotifyContentDownloader to download service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c03f241c04832ba93e71508891739b