### PR TITLE
Add gradient footer matching header styling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Header from './components/Header';
+import Footer from './components/Footer';
 import ArtistBrowserPage from './pages/ArtistBrowserPage';
 import SpotifyDownloadPage from './pages/SpotifyDownloadPage';
 import ArtistDetailsPage from './pages/ArtistDetailsPage';
@@ -9,15 +10,20 @@ import CDBurnerPage from './pages/CDBurnerPage';
 
 const App = () => (
   <Router>
-    <Header />
-    <Routes>
-      <Route path="/" element={<ArtistBrowserPage />} />
-      <Route path="/browse" element={<ArtistBrowserPage />} />
-      <Route path="/download" element={<SpotifyDownloadPage />} />
-      <Route path="/artist/:artistId" element={<ArtistDetailsPage />} />
-      <Route path="/album/:albumId" element={<AlbumDetailsPage />} />
-      <Route path="/burn-cd" element={<CDBurnerPage />} />
-    </Routes>
+    <div className="flex min-h-screen flex-col bg-gray-950">
+      <Header />
+      <main className="flex-1 bg-gray-900 text-white">
+        <Routes>
+          <Route path="/" element={<ArtistBrowserPage />} />
+          <Route path="/browse" element={<ArtistBrowserPage />} />
+          <Route path="/download" element={<SpotifyDownloadPage />} />
+          <Route path="/artist/:artistId" element={<ArtistDetailsPage />} />
+          <Route path="/album/:albumId" element={<AlbumDetailsPage />} />
+          <Route path="/burn-cd" element={<CDBurnerPage />} />
+        </Routes>
+      </main>
+      <Footer />
+    </div>
   </Router>
 );
 

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Link, NavLink } from 'react-router-dom';
+
+const FOOTER_LINKS = [
+  { label: 'Artists', to: '/browse' },
+  { label: 'Download', to: '/download' },
+  { label: 'Burner', to: '/burn-cd' },
+];
+
+const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="relative isolate overflow-hidden bg-gradient-to-r from-slate-950 via-slate-900 to-slate-800 text-slate-200 shadow-lg">
+      <div
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_bottom,rgba(56,189,248,0.2),transparent_62%)]"
+        aria-hidden
+      />
+      <div className="container relative z-10 mx-auto px-4 py-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-3 text-lg font-semibold text-white transition hover:text-sky-200"
+            >
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-xl text-sky-300 ring-1 ring-inset ring-sky-400/40">
+                💿
+              </span>
+              <span>CD Collector</span>
+            </Link>
+            <p className="text-sm text-slate-300 md:text-base">
+              © {currentYear} CD Collector. Built for music lovers everywhere.
+            </p>
+          </div>
+          <nav aria-label="Footer">
+            <ul className="flex flex-wrap items-center gap-2 text-sm font-medium md:justify-end md:gap-4">
+              {FOOTER_LINKS.map((link) => (
+                <li key={link.to}>
+                  <NavLink
+                    to={link.to}
+                    className={({ isActive }) =>
+                      `rounded-full px-4 py-2 transition duration-200 ${
+                        isActive
+                          ? 'bg-slate-800/80 text-sky-200 ring-1 ring-sky-400/60'
+                          : 'text-slate-300 hover:bg-slate-800/60 hover:text-white'
+                      }`
+                    }
+                  >
+                    {link.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </div>
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-sky-400/70 to-transparent"
+        aria-hidden
+      />
+    </footer>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add a gradient footer component that mirrors the header styling and reuses navigation links
- wrap the app layout with a flex column shell so the new footer sits beneath routed content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca23f62d68832bbc078343651db3d2