### PR TITLE
Add playlist and favorites features

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ from src.interfaces.http.routes import (
     progress_bp,
     config_bp,
     compilation_bp,
+    playlist_bp,
+    favorite_bp,
 )
 
 
@@ -205,6 +207,8 @@ def create_app():
     app.register_blueprint(progress_bp)
     app.register_blueprint(config_bp)
     app.register_blueprint(compilation_bp)
+    app.register_blueprint(playlist_bp)
+    app.register_blueprint(favorite_bp)
     # --- NEW: Register the CD Burning Blueprint ---
     app.register_blueprint(cd_burning_bp)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:5000",
   "dependencies": {
     "axios": "^1.9.0",
+    "@tanstack/react-query": "^5.59.16",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Header from './shared/components/Header';
 import Footer from './shared/components/Footer';
@@ -15,36 +16,44 @@ import CompilationSidebar from './features/compilations/components/CompilationSi
 import PlayerBar from './shared/components/PlayerBar.jsx';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import MyPlaylistsPage from './features/playlists/pages/MyPlaylistsPage.jsx';
+import FavoritesPage from './features/favorites/pages/FavoritesPage.jsx';
+
+const queryClient = new QueryClient();
 
 const App = () => (
-  <AuthProvider>
-    <ThemeProvider>
-      <PlayerProvider>
-        <CompilationProvider>
-          <Router>
-            <div className="flex min-h-screen flex-col bg-brand-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-              <Header />
-              <main className="flex-1 bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100">
-                <Routes>
-                  <Route path="/" element={<ArtistBrowserPage />} />
-                  <Route path="/browse" element={<ArtistBrowserPage />} />
-                  <Route path="/download" element={<DownloadPage />} />
-                  <Route path="/artist/:artistId" element={<ArtistDetailsPage />} />
-                  <Route path="/album/:albumId" element={<AlbumDetailsPage />} />
-                  <Route path="/burn-cd" element={<CDBurnerPage />} />
-                  <Route path="/login" element={<LoginPage />} />
-                  <Route path="/register" element={<RegisterPage />} />
-                </Routes>
-              </main>
-              <Footer />
-            </div>
-            <CompilationSidebar />
-          </Router>
-          <PlayerBar />
-        </CompilationProvider>
-      </PlayerProvider>
-    </ThemeProvider>
-  </AuthProvider>
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider>
+      <ThemeProvider>
+        <PlayerProvider>
+          <CompilationProvider>
+            <Router>
+              <div className="flex min-h-screen flex-col bg-brand-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+                <Header />
+                <main className="flex-1 bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-100">
+                  <Routes>
+                    <Route path="/" element={<ArtistBrowserPage />} />
+                    <Route path="/browse" element={<ArtistBrowserPage />} />
+                    <Route path="/download" element={<DownloadPage />} />
+                    <Route path="/playlists" element={<MyPlaylistsPage />} />
+                    <Route path="/favorites" element={<FavoritesPage />} />
+                    <Route path="/artist/:artistId" element={<ArtistDetailsPage />} />
+                    <Route path="/album/:albumId" element={<AlbumDetailsPage />} />
+                    <Route path="/burn-cd" element={<CDBurnerPage />} />
+                    <Route path="/login" element={<LoginPage />} />
+                    <Route path="/register" element={<RegisterPage />} />
+                  </Routes>
+                </main>
+                <Footer />
+              </div>
+              <CompilationSidebar />
+            </Router>
+            <PlayerBar />
+          </CompilationProvider>
+        </PlayerProvider>
+      </ThemeProvider>
+    </AuthProvider>
+  </QueryClientProvider>
 );
 
 export default App;

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -46,5 +46,18 @@ export const endpoints = {
   config: {
     frontend: () => `${API_BASE_URL}/api/config/frontend`,
   },
+  playlists: {
+    list: () => `${API_BASE_URL}/api/playlists`,
+    detail: (id) => `${API_BASE_URL}/api/playlists/${id}`,
+    tracks: (id) => `${API_BASE_URL}/api/playlists/${id}/tracks`,
+    reorder: (id) => `${API_BASE_URL}/api/playlists/${id}/tracks/reorder`,
+  },
+  favorites: {
+    list: () => `${API_BASE_URL}/api/favorites`,
+    summary: () => `${API_BASE_URL}/api/favorites/summary`,
+    status: () => `${API_BASE_URL}/api/favorites/status`,
+    toggle: () => `${API_BASE_URL}/api/favorites/toggle`,
+    remove: (id) => `${API_BASE_URL}/api/favorites/${id}`,
+  },
   progressStream: () => `${API_BASE_URL}/api/progress/stream`,
 };

--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -23,3 +23,4 @@ http.interceptors.response.use(
 export const get = (url, config) => http.get(url, config).then((resp) => resp.data);
 export const post = (url, body, config) => http.post(url, body, config).then((resp) => resp.data);
 export const del = (url, config) => http.delete(url, config).then((resp) => resp.data);
+export const put = (url, body, config) => http.put(url, body, config).then((resp) => resp.data);

--- a/frontend/src/features/catalog/components/TrackListDiscovery.jsx
+++ b/frontend/src/features/catalog/components/TrackListDiscovery.jsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { formatDuration } from '../../../shared/utils/formatting';
 import CompilationContext from '../../compilations/context/CompilationContext.jsx';
 import { useAuth } from '../../../shared/hooks/useAuth';
+import TrackTile from '../../../shared/components/TrackTile.jsx';
 
 const TrackListDiscovery = ({ tracks }) => {
   const compilation = useContext(CompilationContext);
@@ -15,50 +15,50 @@ const TrackListDiscovery = ({ tracks }) => {
       {tracks.map((track, index) => {
         const id = track.spotify_id || track.id || track.url || track.uri;
         const inCart = id ? compilation?.isInCompilation(id) : false;
-        const handleToggle = (e) => {
-          e.stopPropagation();
-          if (!id || !compilation) return;
-          if (inCart) {
-            compilation.remove(id);
-          } else {
-            compilation.add({
-              spotify_id: track.spotify_id || id,
-              title: track.title,
-              artists: track.artists || [],
-              duration_ms: track.duration_ms,
-              albumId: track.albumId,
-              spotify_url: track.spotify_url,
-              url: track.url,
-              uri: track.uri,
-            });
-          }
-        };
-
-        return (
-          <li
-            key={id || index}
-            className="bg-brand-50 dark:bg-gray-800 p-4 rounded-lg shadow flex flex-col sm:flex-row justify-between items-center ring-1 ring-brand-100 dark:ring-0"
-          >
-            <div className="flex-1 text-left mb-2 sm:mb-0">
-              <p className="text-lg font-medium text-slate-900 dark:text-white">
-                {(track.track_number ?? index + 1)}. {track.title}
-              </p>
-              <p className="text-sm text-slate-600 dark:text-gray-400">{(track.artists || []).join(', ')}</p>
-            </div>
-            <div className="flex items-center gap-3">
-              {user && (
+        const renderActions = user && compilation
+          ? () => {
+              const handleToggle = (event) => {
+                event.stopPropagation();
+                if (!id) return;
+                if (inCart) {
+                  compilation.remove(id);
+                } else {
+                  compilation.add({
+                    spotify_id: track.spotify_id || id,
+                    title: track.title,
+                    artists: track.artists || [],
+                    duration_ms: track.duration_ms,
+                    albumId: track.albumId,
+                    spotify_url: track.spotify_url,
+                    url: track.url,
+                    uri: track.uri,
+                  });
+                }
+              };
+              return (
                 <button
                   type="button"
                   onClick={handleToggle}
-                  className={`px-2 py-1 rounded text-sm ${inCart ? 'bg-brandError-600 text-white hover:bg-brandError-700' : 'bg-brand-600 text-white hover:bg-brand-700'}`}
+                  className={`px-2 py-1 rounded text-sm ${
+                    inCart
+                      ? 'bg-brandError-600 text-white hover:bg-brandError-700'
+                      : 'bg-brand-600 text-white hover:bg-brand-700'
+                  }`}
                   title={inCart ? 'Remove from compilation' : 'Add to compilation'}
                 >
                   {inCart ? 'Remove' : '+'}
                 </button>
-              )}
-              <p className="text-slate-600 dark:text-gray-400 text-sm">{formatDuration(track.duration_ms)}</p>
-            </div>
-          </li>
+              );
+            }
+          : undefined;
+
+        return (
+          <TrackTile
+            key={id || index}
+            track={track}
+            index={index}
+            renderActions={renderActions}
+          />
         );
       })}
     </ul>

--- a/frontend/src/features/catalog/pages/AlbumDetailsPage.js
+++ b/frontend/src/features/catalog/pages/AlbumDetailsPage.js
@@ -4,6 +4,8 @@ import TrackListDiscovery from '../components/TrackListDiscovery.jsx';
 import { useAuth } from '../../../shared/hooks/useAuth';
 import { endpoints } from '../../../api/client';
 import { get } from '../../../api/http';
+import FavoriteButton from '../../../features/favorites/components/FavoriteButton.jsx';
+import FAVORITE_TOKENS from '../../../theme/tokens';
 
 const FALLBACK_IMAGE = 'https://via.placeholder.com/300x300.png?text=No+Cover';
 
@@ -99,6 +101,17 @@ const AlbumDetailsPage = () => {
     return list.map((t) => ({ ...t, albumId }));
   }, [albumDetails, albumId]);
 
+  const favoriteMetadata = useMemo(
+    () => ({
+      name: albumDetails?.title,
+      subtitle: albumDetails?.artist,
+      image_url: albumDetails?.image_url,
+      cover_url: albumDetails?.image_url,
+      spotify_url: albumDetails?.spotify_url,
+    }),
+    [albumDetails],
+  );
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -134,6 +147,17 @@ const AlbumDetailsPage = () => {
                 alt={`${albumDetails.title} Album Cover`}
                 className="absolute inset-0 w-full h-full object-cover"
               />
+              <div className="absolute right-3 top-3 flex items-center gap-2">
+                <span className={`${FAVORITE_TOKENS.badgeClasses.base} ${FAVORITE_TOKENS.badgeClasses.active}`}>
+                  Album
+                </span>
+                <FavoriteButton
+                  itemType="album"
+                  itemId={String(albumId)}
+                  metadata={favoriteMetadata}
+                  size="sm"
+                />
+              </div>
             </div>
           </div>
 

--- a/frontend/src/features/catalog/pages/ArtistDetailsPage.js
+++ b/frontend/src/features/catalog/pages/ArtistDetailsPage.js
@@ -4,6 +4,8 @@ import AlbumGallery from '../../../shared/components/AlbumGallery';
 import AlbumCard, { AlbumCardVariant } from '../../../shared/components/AlbumCard';
 import { endpoints } from '../../../api/client';
 import { get } from '../../../api/http';
+import FavoriteButton from '../../../features/favorites/components/FavoriteButton.jsx';
+import FAVORITE_TOKENS from '../../../theme/tokens';
 
 const FALLBACK_IMAGE = 'https://via.placeholder.com/200?text=No+Image';
 
@@ -82,6 +84,16 @@ const ArtistDetailsPage = () => {
     };
   }, [artistDetails, artistId]);
 
+  const favoriteMetadata = useMemo(
+    () => ({
+      name: artistDetails?.name,
+      subtitle: genresLabel,
+      image_url: artistDetails?.image,
+      url: artistDetails?.external_urls?.spotify,
+    }),
+    [artistDetails, genresLabel],
+  );
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -119,7 +131,20 @@ const ArtistDetailsPage = () => {
             />
           </div>
           <div className="flex-1 flex flex-col items-center text-center px-2">
-            <h1 className="text-5xl font-extrabold text-slate-900 dark:text-white mb-2">{artistDetails.name}</h1>
+            <div className="mb-2 flex items-center gap-3">
+              <h1 className="text-5xl font-extrabold text-slate-900 dark:text-white">{artistDetails.name}</h1>
+              <div className="flex items-center gap-2">
+                <span className={`${FAVORITE_TOKENS.badgeClasses.base} ${FAVORITE_TOKENS.badgeClasses.active}`}>
+                  Artist
+                </span>
+                <FavoriteButton
+                  itemType="artist"
+                  itemId={String(artistDetails.id || artistId)}
+                  metadata={favoriteMetadata}
+                  size="sm"
+                />
+              </div>
+            </div>
             {genresLabel && (
               <p className="text-lg text-slate-600 dark:text-gray-300 mb-2">
                 <span className="font-semibold">Genres:</span> {genresLabel}

--- a/frontend/src/features/favorites/api.js
+++ b/frontend/src/features/favorites/api.js
@@ -1,0 +1,24 @@
+import { endpoints } from '../../api/client';
+import { del, get, post } from '../../api/http';
+
+export const fetchFavorites = (params) =>
+  get(endpoints.favorites.list(), { params });
+
+export const fetchFavoriteSummary = () => get(endpoints.favorites.summary());
+
+export const fetchFavoriteStatus = (params) =>
+  get(endpoints.favorites.status(), { params });
+
+export const toggleFavorite = (payload) =>
+  post(endpoints.favorites.toggle(), payload);
+
+export const removeFavorite = (favoriteId) =>
+  del(endpoints.favorites.remove(favoriteId));
+
+export default {
+  fetchFavorites,
+  fetchFavoriteSummary,
+  fetchFavoriteStatus,
+  toggleFavorite,
+  removeFavorite,
+};

--- a/frontend/src/features/favorites/components/FavoriteButton.jsx
+++ b/frontend/src/features/favorites/components/FavoriteButton.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import FAVORITE_TOKENS from '../../../theme/tokens';
+import { useAuth } from '../../../shared/hooks/useAuth';
+import {
+  useFavoriteStatus,
+  useToggleFavorite,
+} from '../hooks/useFavorites';
+
+const FavoriteButton = ({ itemType, itemId, metadata, className, size }) => {
+  const { user } = useAuth();
+  const status = useFavoriteStatus(itemType, itemId);
+  const toggleFavorite = useToggleFavorite();
+
+  if (!user || !itemType || !itemId) {
+    return null;
+  }
+
+  const favorited = Boolean(status.data?.favorited);
+  const icon = favorited
+    ? FAVORITE_TOKENS.icon.active
+    : FAVORITE_TOKENS.icon.inactive;
+
+  const iconClassName = [
+    FAVORITE_TOKENS.iconClasses.base,
+    favorited
+      ? FAVORITE_TOKENS.iconClasses.active
+      : FAVORITE_TOKENS.iconClasses.inactive,
+    size === 'sm' ? 'text-xl' : '',
+    size === 'lg' ? 'text-3xl' : '',
+    className || '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleToggle = (event) => {
+    event.stopPropagation();
+    toggleFavorite.mutate({
+      item_type: itemType,
+      item_id: itemId,
+      metadata,
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-pressed={favorited}
+      onClick={handleToggle}
+      className="inline-flex items-center justify-center"
+      title={favorited ? 'Remove from favourites' : 'Add to favourites'}
+    >
+      <span className={iconClassName}>{icon}</span>
+    </button>
+  );
+};
+
+FavoriteButton.propTypes = {
+  itemType: PropTypes.oneOf(['artist', 'album', 'track']).isRequired,
+  itemId: PropTypes.string.isRequired,
+  metadata: PropTypes.shape({
+    name: PropTypes.string,
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    artist: PropTypes.string,
+    image_url: PropTypes.string,
+    cover_url: PropTypes.string,
+    url: PropTypes.string,
+    spotify_url: PropTypes.string,
+  }),
+  className: PropTypes.string,
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+};
+
+FavoriteButton.defaultProps = {
+  metadata: {},
+  className: '',
+  size: 'md',
+};
+
+export default FavoriteButton;

--- a/frontend/src/features/favorites/hooks/useFavorites.js
+++ b/frontend/src/features/favorites/hooks/useFavorites.js
@@ -1,0 +1,186 @@
+import { useEffect } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import {
+  fetchFavoriteStatus,
+  fetchFavorites,
+  fetchFavoriteSummary,
+  removeFavorite as removeFavoriteApi,
+  toggleFavorite as toggleFavoriteApi,
+} from '../api';
+import { useAuth } from '../../../shared/hooks/useAuth';
+import { FAVORITE_TYPES } from '../../../theme/tokens';
+
+export const favoriteKeys = {
+  all: ['favorites'],
+  listPrefix: ['favorites', 'list'],
+  list: (type, page, perPage) => [
+    'favorites',
+    'list',
+    type || 'all',
+    page || 1,
+    perPage || 20,
+  ],
+  summary: ['favorites', 'summary'],
+  status: (type, id) => ['favorites', 'status', type || 'unknown', id || 'unknown'],
+};
+
+const favoriteEvents = new EventTarget();
+const FAVORITE_EVENT_NAME = 'favorite-change';
+
+export const emitFavoriteChange = (detail) => {
+  favoriteEvents.dispatchEvent(new CustomEvent(FAVORITE_EVENT_NAME, { detail }));
+};
+
+export const useFavoriteEvents = (handler) => {
+  useEffect(() => {
+    if (typeof handler !== 'function') return undefined;
+    const listener = (event) => handler(event.detail);
+    favoriteEvents.addEventListener(FAVORITE_EVENT_NAME, listener);
+    return () => favoriteEvents.removeEventListener(FAVORITE_EVENT_NAME, listener);
+  }, [handler]);
+};
+
+export const useFavoritesList = ({ page = 1, perPage = 20, type } = {}) => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: favoriteKeys.list(type, page, perPage),
+    queryFn: () =>
+      fetchFavorites({
+        page,
+        per_page: perPage,
+        type: FAVORITE_TYPES.includes(type) ? type : undefined,
+      }),
+    enabled: Boolean(user),
+    staleTime: 1000 * 30,
+    keepPreviousData: true,
+  });
+};
+
+export const useFavoriteSummary = () => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: favoriteKeys.summary,
+    queryFn: fetchFavoriteSummary,
+    enabled: Boolean(user),
+    staleTime: 1000 * 30,
+  });
+};
+
+export const useFavoriteStatus = (itemType, itemId) => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: favoriteKeys.status(itemType, itemId),
+    queryFn: () =>
+      fetchFavoriteStatus({
+        item_type: itemType,
+        item_id: itemId,
+      }),
+    enabled: Boolean(user && itemType && itemId),
+    staleTime: 1000 * 30,
+  });
+};
+
+export const useToggleFavorite = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (variables) => toggleFavoriteApi(variables),
+    onMutate: async (variables) => {
+      const { item_type: itemType, item_id: itemId } = variables;
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: favoriteKeys.status(itemType, itemId) }),
+        queryClient.cancelQueries({ queryKey: favoriteKeys.summary }),
+        queryClient.cancelQueries({ queryKey: favoriteKeys.listPrefix }),
+      ]);
+
+      const previousStatus = queryClient.getQueryData(
+        favoriteKeys.status(itemType, itemId),
+      );
+      const previousSummary = queryClient.getQueryData(favoriteKeys.summary);
+
+      const nextFavorited = !(previousStatus?.favorited);
+      queryClient.setQueryData(favoriteKeys.status(itemType, itemId), {
+        favorited: nextFavorited,
+        favorite: previousStatus?.favorite ?? null,
+      });
+
+      if (previousSummary?.summary) {
+        const draft = { ...previousSummary.summary };
+        const key = FAVORITE_TYPES.includes(itemType) ? itemType : 'unknown';
+        if (nextFavorited) {
+          draft[key] = (draft[key] || 0) + 1;
+          draft.total = (draft.total || 0) + 1;
+        } else {
+          draft[key] = Math.max((draft[key] || 1) - 1, 0);
+          draft.total = Math.max((draft.total || 1) - 1, 0);
+        }
+        queryClient.setQueryData(favoriteKeys.summary, { summary: draft });
+      }
+
+      return { previousStatus, previousSummary };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previousStatus) {
+        queryClient.setQueryData(
+          favoriteKeys.status(variables.item_type, variables.item_id),
+          context.previousStatus,
+        );
+      }
+      if (context?.previousSummary) {
+        queryClient.setQueryData(favoriteKeys.summary, context.previousSummary);
+      }
+    },
+    onSuccess: (data, variables) => {
+      const { item_type: itemType, item_id: itemId } = variables;
+      queryClient.setQueryData(favoriteKeys.status(itemType, itemId), {
+        favorited: Boolean(data?.favorited),
+        favorite: data?.favorite ?? null,
+      });
+      if (data?.summary) {
+        queryClient.setQueryData(favoriteKeys.summary, { summary: data.summary });
+      }
+      queryClient.invalidateQueries({ queryKey: favoriteKeys.listPrefix });
+      emitFavoriteChange({
+        itemType,
+        itemId,
+        favorited: Boolean(data?.favorited),
+        favorite: data?.favorite ?? null,
+        summary: data?.summary ?? null,
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: favoriteKeys.summary });
+    },
+  });
+};
+
+export const useRemoveFavorite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (favoriteId) => removeFavoriteApi(favoriteId),
+    onSuccess: (data, favoriteId) => {
+      queryClient.invalidateQueries({ queryKey: favoriteKeys.listPrefix });
+      if (data?.summary) {
+        queryClient.setQueryData(favoriteKeys.summary, { summary: data.summary });
+      } else {
+        queryClient.invalidateQueries({ queryKey: favoriteKeys.summary });
+      }
+      emitFavoriteChange({ favoriteId, favorited: false });
+    },
+  });
+};
+
+export default {
+  favoriteKeys,
+  useFavoritesList,
+  useFavoriteSummary,
+  useFavoriteStatus,
+  useToggleFavorite,
+  useRemoveFavorite,
+  useFavoriteEvents,
+};

--- a/frontend/src/features/favorites/pages/FavoritesPage.jsx
+++ b/frontend/src/features/favorites/pages/FavoritesPage.jsx
@@ -1,0 +1,246 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+
+import FavoriteButton from '../components/FavoriteButton.jsx';
+import {
+  favoriteKeys,
+  useFavoriteEvents,
+  useFavoriteSummary,
+  useFavoritesList,
+} from '../hooks/useFavorites';
+import FAVORITE_TOKENS, { FAVORITE_TYPES } from '../../../theme/tokens';
+import { useAuth } from '../../../shared/hooks/useAuth';
+
+const FILTERS = [{ key: 'all', label: 'All' }, ...FAVORITE_TYPES.map((type) => ({ key: type, label: type.charAt(0).toUpperCase() + type.slice(1) }))];
+
+const FALLBACK_IMAGE = 'https://via.placeholder.com/200x200.png?text=No+Artwork';
+
+const FavoriteCard = ({ favorite }) => {
+  const metadata = useMemo(
+    () => ({
+      name: favorite.item_name,
+      subtitle: favorite.item_subtitle,
+      image_url: favorite.item_image_url,
+      url: favorite.item_url,
+    }),
+    [favorite.item_name, favorite.item_subtitle, favorite.item_image_url, favorite.item_url],
+  );
+
+  return (
+    <div className="relative flex flex-col overflow-hidden rounded-xl bg-white shadow ring-1 ring-brand-100 transition hover:shadow-lg dark:bg-gray-800 dark:ring-gray-700">
+      <div className="relative">
+        <img
+          src={favorite.item_image_url || FALLBACK_IMAGE}
+          alt={favorite.item_name}
+          className="h-48 w-full object-cover"
+          loading="lazy"
+        />
+        <div className="absolute right-2 top-2">
+          <FavoriteButton
+            itemType={favorite.item_type}
+            itemId={favorite.item_id}
+            metadata={metadata}
+            size="sm"
+          />
+        </div>
+        <span
+          className={`absolute left-2 top-2 ${FAVORITE_TOKENS.badgeClasses.base} ${FAVORITE_TOKENS.badgeClasses.active}`}
+        >
+          {favorite.item_type}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <h3 className="truncate text-lg font-semibold text-slate-900 dark:text-white">
+          {favorite.item_name}
+        </h3>
+        {favorite.item_subtitle && (
+          <p className="truncate text-sm text-slate-600 dark:text-gray-400">
+            {favorite.item_subtitle}
+          </p>
+        )}
+        <div className="mt-auto flex justify-between text-xs text-slate-500 dark:text-gray-400">
+          <span>Added {new Date(favorite.created_at).toLocaleString()}</span>
+          {favorite.item_url && (
+            <a
+              href={favorite.item_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-600 hover:text-brand-500 dark:text-brandDark-300"
+            >
+              Open
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+FavoriteCard.propTypes = {
+  favorite: PropTypes.shape({
+    item_type: PropTypes.string.isRequired,
+    item_id: PropTypes.string.isRequired,
+    item_name: PropTypes.string.isRequired,
+    item_subtitle: PropTypes.string,
+    item_image_url: PropTypes.string,
+    item_url: PropTypes.string,
+    created_at: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const FavoritesPage = () => {
+  const { user, loading } = useAuth();
+  const [activeFilter, setActiveFilter] = useState('all');
+  const [page, setPage] = useState(1);
+  const perPage = 12;
+  const queryClient = useQueryClient();
+
+  useFavoriteEvents(() => {
+    queryClient.invalidateQueries({ queryKey: favoriteKeys.listPrefix });
+    queryClient.invalidateQueries({ queryKey: favoriteKeys.summary });
+  });
+
+  useEffect(() => {
+    setPage(1);
+  }, [activeFilter]);
+
+  const summaryQuery = useFavoriteSummary();
+  const listQuery = useFavoritesList({
+    page,
+    perPage,
+    type: activeFilter === 'all' ? undefined : activeFilter,
+  });
+
+  const favorites = listQuery.data?.items ?? [];
+  const pagination = listQuery.data?.pagination ?? {};
+
+  const summary = useMemo(() => summaryQuery.data?.summary || {}, [summaryQuery.data]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-brand-50 dark:bg-slate-950">
+        <p className="text-slate-600 dark:text-gray-300">Loading favourites…</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-brand-50 dark:bg-slate-950">
+        <div className="rounded-2xl bg-white p-8 text-center shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:text-gray-200 dark:ring-gray-700">
+          <h1 className="mb-4 text-3xl font-semibold text-slate-900 dark:text-white">Sign in to view favourites</h1>
+          <p className="mb-6 text-slate-600 dark:text-gray-400">
+            Save artists, albums, and tracks once you are logged in.
+          </p>
+          <Link
+            to="/login"
+            className="rounded-full bg-brand-600 px-4 py-2 font-medium text-white transition hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400"
+          >
+            Go to login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-brand-50 py-8 dark:bg-slate-950">
+      <div className="mx-auto max-w-7xl px-4">
+        <header className="mb-8 rounded-2xl bg-white p-6 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:ring-gray-700">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Your favourites</h1>
+              <p className="text-slate-600 dark:text-gray-400">
+                Quick access to artists, albums, and tracks you care about.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {FILTERS.map((filter) => {
+                const count =
+                  filter.key === 'all'
+                    ? summary.total ?? 0
+                    : summary[filter.key] ?? 0;
+                const isActive = activeFilter === filter.key;
+                return (
+                  <button
+                    key={filter.key}
+                    type="button"
+                    onClick={() => setActiveFilter(filter.key)}
+                    className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition ${
+                      isActive
+                        ? 'border-brand-500 bg-brand-100 text-brand-700 dark:border-brandDark-400 dark:bg-brandDark-900/40 dark:text-brandDark-200'
+                        : 'border-transparent bg-slate-100 text-slate-600 hover:bg-brand-50 hover:text-brand-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    {filter.label}
+                    <span className={`${FAVORITE_TOKENS.badgeClasses.base} ${FAVORITE_TOKENS.badgeClasses.inactive}`}>
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </header>
+
+        <section className="rounded-2xl bg-white p-6 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:ring-gray-700">
+          {listQuery.isLoading ? (
+            <div className="flex min-h-[200px] items-center justify-center text-slate-600 dark:text-gray-300">
+              Loading favourites…
+            </div>
+          ) : favorites.length === 0 ? (
+            <div className="flex min-h-[200px] flex-col items-center justify-center gap-3 text-center">
+              <span className="text-6xl">{FAVORITE_TOKENS.icon.inactive}</span>
+              <p className="max-w-md text-slate-600 dark:text-gray-400">
+                No favourites found yet. Browse artists or albums and tap the star icon to pin them here.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {favorites.map((favorite) => (
+                  <FavoriteCard key={`${favorite.item_type}:${favorite.item_id}`} favorite={favorite} />
+                ))}
+              </div>
+              <div className="mt-6 flex items-center justify-between text-sm text-slate-600 dark:text-gray-400">
+                <span>
+                  Page {pagination.page || 1} of {pagination.pages || 1}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                    disabled={!pagination.has_prev}
+                    className={`rounded-full px-4 py-2 font-medium ${
+                      pagination.has_prev
+                        ? 'bg-brand-600 text-white hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400'
+                        : 'bg-slate-200 text-slate-500 dark:bg-gray-700 dark:text-gray-500'
+                    }`}
+                  >
+                    Previous
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPage((prev) => (pagination.has_next ? prev + 1 : prev))}
+                    disabled={!pagination.has_next}
+                    className={`rounded-full px-4 py-2 font-medium ${
+                      pagination.has_next
+                        ? 'bg-brand-600 text-white hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400'
+                        : 'bg-slate-200 text-slate-500 dark:bg-gray-700 dark:text-gray-500'
+                    }`}
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default FavoritesPage;

--- a/frontend/src/features/playlists/api.js
+++ b/frontend/src/features/playlists/api.js
@@ -1,0 +1,36 @@
+import { endpoints } from '../../api/client';
+import { del, get, post, put } from '../../api/http';
+
+export const fetchPlaylists = (params) =>
+  get(endpoints.playlists.list(), { params });
+
+export const fetchPlaylist = (id) =>
+  get(endpoints.playlists.detail(id));
+
+export const createPlaylist = (payload) =>
+  post(endpoints.playlists.list(), payload);
+
+export const updatePlaylist = (id, payload) =>
+  put(endpoints.playlists.detail(id), payload);
+
+export const deletePlaylist = (id) => del(endpoints.playlists.detail(id));
+
+export const addTracksToPlaylist = (id, tracks) =>
+  post(endpoints.playlists.tracks(id), { tracks });
+
+export const removeTrackFromPlaylist = (id, entryId) =>
+  del(`${endpoints.playlists.tracks(id)}/${entryId}`);
+
+export const reorderPlaylistTracks = (id, order) =>
+  put(endpoints.playlists.reorder(id), { order });
+
+export default {
+  fetchPlaylists,
+  fetchPlaylist,
+  createPlaylist,
+  updatePlaylist,
+  deletePlaylist,
+  addTracksToPlaylist,
+  removeTrackFromPlaylist,
+  reorderPlaylistTracks,
+};

--- a/frontend/src/features/playlists/components/PlaylistCreateForm.jsx
+++ b/frontend/src/features/playlists/components/PlaylistCreateForm.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const PlaylistCreateForm = ({ onCreate, isSubmitting }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('Give your playlist a name before saving.');
+      return;
+    }
+    setError('');
+    await onCreate({
+      name: trimmedName,
+      description: description.trim() || null,
+    });
+    setName('');
+    setDescription('');
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-2xl bg-white p-6 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:ring-gray-700"
+    >
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+          Create a new playlist
+        </h2>
+        <p className="text-sm text-slate-600 dark:text-gray-400">
+          Organise your favourite tracks into a personal collection.
+        </p>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300" htmlFor="playlist-name">
+          Name
+        </label>
+        <input
+          id="playlist-name"
+          type="text"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          placeholder="Road trip mix"
+          disabled={isSubmitting}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-700 dark:text-gray-300" htmlFor="playlist-description">
+          Description
+        </label>
+        <textarea
+          id="playlist-description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          rows={3}
+          className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+          placeholder="A set of songs to keep me energised on long drives"
+          disabled={isSubmitting}
+        />
+      </div>
+      {error && <p className="text-sm text-brandError-600 dark:text-brandError-400">{error}</p>}
+      <button
+        type="submit"
+        className="rounded-full bg-brand-600 px-4 py-2 font-medium text-white transition hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-brandDark-500 dark:hover:bg-brandDark-400"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? 'Creating…' : 'Create playlist'}
+      </button>
+    </form>
+  );
+};
+
+PlaylistCreateForm.propTypes = {
+  onCreate: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool,
+};
+
+PlaylistCreateForm.defaultProps = {
+  isSubmitting: false,
+};
+
+export default PlaylistCreateForm;

--- a/frontend/src/features/playlists/components/PlaylistDetail.jsx
+++ b/frontend/src/features/playlists/components/PlaylistDetail.jsx
@@ -1,0 +1,231 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import TrackTile from '../../../shared/components/TrackTile.jsx';
+
+const emptyTrack = {
+  title: '',
+  artists: '',
+  spotify_id: '',
+  duration_ms: '',
+  album_name: '',
+};
+
+const PlaylistDetail = ({
+  playlist,
+  onAddTrack,
+  onRemoveTrack,
+  onReorderTracks,
+  isMutating,
+}) => {
+  const [draftTrack, setDraftTrack] = useState(emptyTrack);
+  const [error, setError] = useState('');
+
+  const orderedTracks = useMemo(() => {
+    const items = playlist?.tracks || [];
+    return [...items].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+  }, [playlist]);
+
+  const handleInputChange = (field) => (event) => {
+    setDraftTrack((current) => ({ ...current, [field]: event.target.value }));
+  };
+
+  const handleAddTrack = async (event) => {
+    event.preventDefault();
+    const title = draftTrack.title.trim();
+    const spotifyId = draftTrack.spotify_id.trim();
+    if (!title || !spotifyId) {
+      setError('Provide at least a title and Spotify ID to add a track.');
+      return;
+    }
+    const payload = {
+      title,
+      spotify_id: spotifyId,
+      artists: draftTrack.artists
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean),
+      duration_ms: draftTrack.duration_ms ? Number(draftTrack.duration_ms) : undefined,
+      album_name: draftTrack.album_name.trim() || undefined,
+    };
+    setError('');
+    await onAddTrack(payload);
+    setDraftTrack(emptyTrack);
+  };
+
+  const moveTrack = (entryId, direction) => {
+    const currentOrder = orderedTracks.map((entry) => entry.id);
+    const index = currentOrder.indexOf(entryId);
+    if (index === -1) return;
+    if (direction === 'up' && index === 0) return;
+    if (direction === 'down' && index === currentOrder.length - 1) return;
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    const nextOrder = [...currentOrder];
+    const [moved] = nextOrder.splice(index, 1);
+    nextOrder.splice(targetIndex, 0, moved);
+    onReorderTracks(nextOrder);
+  };
+
+  return (
+    <div className="space-y-6 rounded-2xl bg-white p-6 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:ring-gray-700">
+      <header className="flex flex-col gap-2">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-white">
+          {playlist?.name || 'Playlist'}
+        </h2>
+        {playlist?.description && (
+          <p className="text-slate-600 dark:text-gray-400">{playlist.description}</p>
+        )}
+        <p className="text-sm text-slate-500 dark:text-gray-500">
+          Created {playlist?.created_at ? new Date(playlist.created_at).toLocaleString() : 'recently'}
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Tracks</h3>
+        {orderedTracks.length === 0 ? (
+          <p className="rounded-lg bg-brand-50 p-4 text-sm text-slate-600 dark:bg-gray-800 dark:text-gray-300">
+            This playlist is empty. Add a track using the form below.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {orderedTracks.map((entry, index) => {
+              const track = entry.track || entry.track_snapshot || entry;
+              return (
+                <TrackTile
+                  key={entry.id}
+                  track={track}
+                  index={index}
+                  renderActions={() => (
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => moveTrack(entry.id, 'up')}
+                        className="rounded-full bg-slate-200 px-2 py-1 text-sm text-slate-700 hover:bg-slate-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                        disabled={index === 0}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveTrack(entry.id, 'down')}
+                        className="rounded-full bg-slate-200 px-2 py-1 text-sm text-slate-700 hover:bg-slate-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                        disabled={index === orderedTracks.length - 1}
+                      >
+                        ↓
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onRemoveTrack(entry)}
+                        className="rounded-full bg-brandError-600 px-3 py-1 text-sm font-medium text-white hover:bg-brandError-500 dark:bg-brandError-500 dark:hover:bg-brandError-400"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
+                />
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Add track manually</h3>
+        <form className="mt-4 grid gap-4 md:grid-cols-2" onSubmit={handleAddTrack}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-gray-300">
+            Title
+            <input
+              type="text"
+              value={draftTrack.title}
+              onChange={handleInputChange('title')}
+              required
+              className="rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="Song title"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-gray-300">
+            Spotify ID
+            <input
+              type="text"
+              value={draftTrack.spotify_id}
+              onChange={handleInputChange('spotify_id')}
+              required
+              className="rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="e.g. 4uLU6hMCjMI75M1A2tKUQC"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-gray-300">
+            Artists (comma separated)
+            <input
+              type="text"
+              value={draftTrack.artists}
+              onChange={handleInputChange('artists')}
+              className="rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="Artist 1, Artist 2"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-gray-300">
+            Duration (ms)
+            <input
+              type="number"
+              value={draftTrack.duration_ms}
+              onChange={handleInputChange('duration_ms')}
+              className="rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="210000"
+            />
+          </label>
+          <label className="md:col-span-2 flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-gray-300">
+            Album name (optional)
+            <input
+              type="text"
+              value={draftTrack.album_name}
+              onChange={handleInputChange('album_name')}
+              className="rounded-lg border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              placeholder="Album title"
+            />
+          </label>
+          {error && (
+            <p className="md:col-span-2 text-sm text-brandError-600 dark:text-brandError-400">{error}</p>
+          )}
+          <div className="md:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              className="rounded-full bg-brand-600 px-4 py-2 font-medium text-white transition hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-brandDark-500 dark:hover:bg-brandDark-400"
+              disabled={isMutating}
+            >
+              {isMutating ? 'Adding…' : 'Add track'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+PlaylistDetail.propTypes = {
+  playlist: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    name: PropTypes.string,
+    description: PropTypes.string,
+    created_at: PropTypes.string,
+    tracks: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+        position: PropTypes.number,
+        track: PropTypes.object,
+        track_snapshot: PropTypes.object,
+      }),
+    ),
+  }),
+  onAddTrack: PropTypes.func.isRequired,
+  onRemoveTrack: PropTypes.func.isRequired,
+  onReorderTracks: PropTypes.func.isRequired,
+  isMutating: PropTypes.bool,
+};
+
+PlaylistDetail.defaultProps = {
+  playlist: null,
+  isMutating: false,
+};
+
+export default PlaylistDetail;

--- a/frontend/src/features/playlists/components/PlaylistList.jsx
+++ b/frontend/src/features/playlists/components/PlaylistList.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PlaylistList = ({ playlists, activePlaylistId, onSelect, onDelete }) => {
+  if (!playlists || playlists.length === 0) {
+    return (
+      <div className="rounded-2xl bg-white p-6 text-center text-slate-600 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-700">
+        No playlists yet. Use the form to create your first collection.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {playlists.map((playlist) => {
+        const isActive = playlist.id === activePlaylistId;
+        const trackCount = Array.isArray(playlist.tracks)
+          ? playlist.tracks.length
+          : playlist.track_count ?? 0;
+        return (
+          <li key={playlist.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(playlist)}
+              className={`flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left transition ${
+                isActive
+                  ? 'border-brand-500 bg-brand-100 text-brand-800 shadow-sm dark:border-brandDark-400 dark:bg-brandDark-900/40 dark:text-brandDark-200'
+                  : 'border-transparent bg-white text-slate-800 hover:border-brand-200 hover:bg-brand-50 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-brandDark-500/40 dark:hover:bg-gray-800'
+              }`}
+            >
+              <div>
+                <h3 className="text-lg font-semibold">{playlist.name}</h3>
+                {playlist.description && (
+                  <p className="text-sm text-slate-600 dark:text-gray-400">
+                    {playlist.description}
+                  </p>
+                )}
+                <p className="text-xs text-slate-500 dark:text-gray-500">
+                  Updated {new Date(playlist.updated_at).toLocaleString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="rounded-full bg-brand-600 px-3 py-1 text-sm font-semibold text-white dark:bg-brandDark-500">
+                  {trackCount} tracks
+                </span>
+                {typeof onDelete === 'function' && (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(playlist);
+                    }}
+                    className="rounded-full bg-brandError-600 px-3 py-1 text-sm font-medium text-white hover:bg-brandError-500 dark:bg-brandError-500 dark:hover:bg-brandError-400"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+PlaylistList.propTypes = {
+  playlists: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      updated_at: PropTypes.string,
+      tracks: PropTypes.array,
+      track_count: PropTypes.number,
+    }),
+  ),
+  activePlaylistId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onSelect: PropTypes.func.isRequired,
+  onDelete: PropTypes.func,
+};
+
+PlaylistList.defaultProps = {
+  playlists: [],
+  activePlaylistId: undefined,
+  onDelete: undefined,
+};
+
+export default PlaylistList;

--- a/frontend/src/features/playlists/hooks/usePlaylists.js
+++ b/frontend/src/features/playlists/hooks/usePlaylists.js
@@ -1,0 +1,398 @@
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import {
+  addTracksToPlaylist,
+  createPlaylist as createPlaylistApi,
+  deletePlaylist as deletePlaylistApi,
+  fetchPlaylist,
+  fetchPlaylists,
+  removeTrackFromPlaylist,
+  reorderPlaylistTracks,
+  updatePlaylist as updatePlaylistApi,
+} from '../api';
+import { useAuth } from '../../../shared/hooks/useAuth';
+
+export const PLAYLIST_DEFAULT_PAGE_SIZE = 10;
+
+export const playlistKeys = {
+  all: ['playlists'],
+  listPrefix: ['playlists', 'list'],
+  list: (page = 1, perPage = PLAYLIST_DEFAULT_PAGE_SIZE) => [
+    'playlists',
+    'list',
+    page,
+    perPage,
+  ],
+  detailPrefix: ['playlists', 'detail'],
+  detail: (id) => ['playlists', 'detail', id],
+};
+
+const nowIso = () => new Date().toISOString();
+
+export const usePlaylistList = ({
+  page = 1,
+  perPage = PLAYLIST_DEFAULT_PAGE_SIZE,
+} = {}) => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: playlistKeys.list(page, perPage),
+    queryFn: () => fetchPlaylists({ page, per_page: perPage }),
+    enabled: Boolean(user),
+    keepPreviousData: true,
+    staleTime: 1000 * 30,
+  });
+};
+
+export const usePlaylist = (playlistId) => {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: playlistKeys.detail(playlistId),
+    queryFn: () => fetchPlaylist(playlistId).then((response) => response.playlist),
+    enabled: Boolean(user && playlistId),
+    staleTime: 1000 * 30,
+  });
+};
+
+const applyToListCaches = (queryClient, updater) => {
+  const queries = queryClient.getQueriesData({ queryKey: playlistKeys.listPrefix });
+  queries.forEach(([queryKey, data]) => {
+    if (!data) return;
+    const nextData = updater(data);
+    queryClient.setQueryData(queryKey, nextData);
+  });
+};
+
+export const usePlaylistMutations = () => {
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: (payload) => createPlaylistApi(payload),
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.listPrefix });
+      const optimisticId = `temp-${Date.now()}`;
+      const timestamp = nowIso();
+      const optimisticPlaylist = {
+        id: optimisticId,
+        name: payload.name,
+        description: payload.description ?? null,
+        created_at: timestamp,
+        updated_at: timestamp,
+        tracks: payload.tracks ?? [],
+      };
+
+      const listKey = playlistKeys.list(1, PLAYLIST_DEFAULT_PAGE_SIZE);
+      const previousList = queryClient.getQueryData(listKey);
+      if (previousList) {
+        const perPage = previousList.pagination?.per_page || PLAYLIST_DEFAULT_PAGE_SIZE;
+        const nextItems = [optimisticPlaylist, ...(previousList.items || [])].slice(
+          0,
+          perPage,
+        );
+        queryClient.setQueryData(listKey, {
+          ...previousList,
+          items: nextItems,
+          pagination: previousList.pagination
+            ? {
+                ...previousList.pagination,
+                total: (previousList.pagination.total || 0) + 1,
+              }
+            : undefined,
+        });
+      }
+
+      queryClient.setQueryData(playlistKeys.detail(optimisticId), optimisticPlaylist);
+
+      return { previousList, optimisticId };
+    },
+    onError: (_error, _payload, context) => {
+      if (context?.previousList) {
+        queryClient.setQueryData(
+          playlistKeys.list(1, PLAYLIST_DEFAULT_PAGE_SIZE),
+          context.previousList,
+        );
+      }
+    },
+    onSuccess: (response, _payload, context) => {
+      const playlist = response?.playlist;
+      if (!playlist) {
+        queryClient.invalidateQueries({ queryKey: playlistKeys.listPrefix });
+        return;
+      }
+      queryClient.setQueryData(playlistKeys.detail(playlist.id), playlist);
+      if (context?.optimisticId && playlist.id !== context.optimisticId) {
+        queryClient.removeQueries({ queryKey: playlistKeys.detail(context.optimisticId) });
+      }
+
+      const listKey = playlistKeys.list(1, PLAYLIST_DEFAULT_PAGE_SIZE);
+      const existing = queryClient.getQueryData(listKey);
+      if (existing) {
+        const perPage = existing.pagination?.per_page || PLAYLIST_DEFAULT_PAGE_SIZE;
+        const filtered = (existing.items || []).filter(
+          (item) => item.id !== context?.optimisticId && item.id !== playlist.id,
+        );
+        queryClient.setQueryData(listKey, {
+          ...existing,
+          items: [playlist, ...filtered].slice(0, perPage),
+        });
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: playlistKeys.listPrefix });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }) => updatePlaylistApi(id, data),
+    onMutate: async ({ id, data }) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.detail(id) });
+      const previousDetail = queryClient.getQueryData(playlistKeys.detail(id));
+      if (previousDetail) {
+        const optimistic = {
+          ...previousDetail,
+          ...data,
+          updated_at: nowIso(),
+        };
+        queryClient.setQueryData(playlistKeys.detail(id), optimistic);
+        applyToListCaches(queryClient, (old) => {
+          const items = old.items || [];
+          const idx = items.findIndex((item) => item.id === id);
+          if (idx === -1) return old;
+          const nextItems = [...items];
+          nextItems[idx] = { ...nextItems[idx], ...optimistic };
+          return { ...old, items: nextItems };
+        });
+      }
+
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previousDetail) {
+        queryClient.setQueryData(playlistKeys.detail(variables.id), context.previousDetail);
+        applyToListCaches(queryClient, (old) => {
+          const items = old.items || [];
+          const idx = items.findIndex((item) => item.id === variables.id);
+          if (idx === -1) return old;
+          const nextItems = [...items];
+          nextItems[idx] = { ...nextItems[idx], ...context.previousDetail };
+          return { ...old, items: nextItems };
+        });
+      }
+    },
+    onSuccess: (response) => {
+      const playlist = response?.playlist;
+      if (!playlist) {
+        return;
+      }
+      queryClient.setQueryData(playlistKeys.detail(playlist.id), playlist);
+      applyToListCaches(queryClient, (old) => {
+        const items = old.items || [];
+        const idx = items.findIndex((item) => item.id === playlist.id);
+        if (idx === -1) return old;
+        const nextItems = [...items];
+        nextItems[idx] = { ...nextItems[idx], ...playlist };
+        return { ...old, items: nextItems };
+      });
+    },
+    onSettled: (response, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: playlistKeys.detail(variables.id) });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id) => deletePlaylistApi(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.listPrefix });
+      const previousLists = queryClient.getQueriesData({ queryKey: playlistKeys.listPrefix });
+      const previousDetail = queryClient.getQueryData(playlistKeys.detail(id));
+      applyToListCaches(queryClient, (old) => {
+        const items = old.items || [];
+        const nextItems = items.filter((item) => item.id !== id);
+        if (nextItems.length === items.length) return old;
+        return {
+          ...old,
+          items: nextItems,
+          pagination: old.pagination
+            ? {
+                ...old.pagination,
+                total: Math.max((old.pagination.total || 1) - 1, 0),
+              }
+            : undefined,
+        };
+      });
+      return { previousLists, previousDetail };
+    },
+    onError: (_error, id, context) => {
+      if (context?.previousLists) {
+        context.previousLists.forEach(([key, data]) => {
+          queryClient.setQueryData(key, data);
+        });
+      }
+      if (context?.previousDetail) {
+        queryClient.setQueryData(playlistKeys.detail(id), context.previousDetail);
+      }
+    },
+    onSuccess: (_response, id) => {
+      queryClient.removeQueries({ queryKey: playlistKeys.detail(id) });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: playlistKeys.listPrefix });
+    },
+  });
+
+  const addTracksMutation = useMutation({
+    mutationFn: ({ id, tracks }) => addTracksToPlaylist(id, tracks),
+    onMutate: async ({ id, tracks }) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.detail(id) });
+      const previousDetail = queryClient.getQueryData(playlistKeys.detail(id));
+      if (previousDetail) {
+        const timestamp = nowIso();
+        const existingTracks = previousDetail.tracks || [];
+        const optimisticTracks = tracks.map((track, index) => ({
+          id: `temp-${Date.now()}-${index}`,
+          playlist_id: id,
+          track,
+          position: existingTracks.length + index,
+          added_at: timestamp,
+        }));
+        queryClient.setQueryData(playlistKeys.detail(id), {
+          ...previousDetail,
+          tracks: [...existingTracks, ...optimisticTracks],
+          updated_at: timestamp,
+        });
+      }
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previousDetail) {
+        queryClient.setQueryData(playlistKeys.detail(variables.id), context.previousDetail);
+      }
+    },
+    onSuccess: (response) => {
+      const playlist = response?.playlist;
+      if (!playlist) {
+        return;
+      }
+      queryClient.setQueryData(playlistKeys.detail(playlist.id), playlist);
+      applyToListCaches(queryClient, (old) => {
+        const items = old.items || [];
+        const idx = items.findIndex((item) => item.id === playlist.id);
+        if (idx === -1) return old;
+        const nextItems = [...items];
+        nextItems[idx] = { ...nextItems[idx], ...playlist };
+        return { ...old, items: nextItems };
+      });
+    },
+  });
+
+  const removeTrackMutation = useMutation({
+    mutationFn: ({ id, entryId }) => removeTrackFromPlaylist(id, entryId),
+    onMutate: async ({ id, entryId }) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.detail(id) });
+      const previousDetail = queryClient.getQueryData(playlistKeys.detail(id));
+      if (previousDetail) {
+        const nextTracks = (previousDetail.tracks || []).filter((track) => track.id !== entryId);
+        queryClient.setQueryData(playlistKeys.detail(id), {
+          ...previousDetail,
+          tracks: nextTracks.map((track, index) => ({ ...track, position: index })),
+          updated_at: nowIso(),
+        });
+      }
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previousDetail) {
+        queryClient.setQueryData(playlistKeys.detail(variables.id), context.previousDetail);
+      }
+    },
+    onSuccess: (response) => {
+      const playlist = response?.playlist;
+      if (!playlist) {
+        return;
+      }
+      queryClient.setQueryData(playlistKeys.detail(playlist.id), playlist);
+      applyToListCaches(queryClient, (old) => {
+        const items = old.items || [];
+        const idx = items.findIndex((item) => item.id === playlist.id);
+        if (idx === -1) return old;
+        const nextItems = [...items];
+        nextItems[idx] = { ...nextItems[idx], ...playlist };
+        return { ...old, items: nextItems };
+      });
+    },
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: ({ id, order }) => reorderPlaylistTracks(id, order),
+    onMutate: async ({ id, order }) => {
+      await queryClient.cancelQueries({ queryKey: playlistKeys.detail(id) });
+      const previousDetail = queryClient.getQueryData(playlistKeys.detail(id));
+      if (previousDetail) {
+        const trackMap = new Map((previousDetail.tracks || []).map((track) => [track.id, track]));
+        const reordered = order
+          .map((entryId) => trackMap.get(entryId))
+          .filter(Boolean)
+          .map((track, index) => ({ ...track, position: index }));
+        const remaining = (previousDetail.tracks || [])
+          .filter((track) => !order.includes(track.id))
+          .map((track, index) => ({ ...track, position: order.length + index }));
+        queryClient.setQueryData(playlistKeys.detail(id), {
+          ...previousDetail,
+          tracks: [...reordered, ...remaining],
+          updated_at: nowIso(),
+        });
+      }
+      return { previousDetail };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previousDetail) {
+        queryClient.setQueryData(playlistKeys.detail(variables.id), context.previousDetail);
+      }
+    },
+    onSuccess: (response) => {
+      const playlist = response?.playlist;
+      if (!playlist) {
+        return;
+      }
+      queryClient.setQueryData(playlistKeys.detail(playlist.id), playlist);
+    },
+  });
+
+  return useMemo(
+    () => ({
+      createPlaylist: (payload) => createMutation.mutateAsync(payload),
+      updatePlaylist: (id, data) => updateMutation.mutateAsync({ id, data }),
+      deletePlaylist: (id) => deleteMutation.mutateAsync(id),
+      addTracks: (id, tracks) => addTracksMutation.mutateAsync({ id, tracks }),
+      removeTrack: (id, entryId) => removeTrackMutation.mutateAsync({ id, entryId }),
+      reorderTracks: (id, order) => reorderMutation.mutateAsync({ id, order }),
+      states: {
+        create: createMutation,
+        update: updateMutation,
+        delete: deleteMutation,
+        addTracks: addTracksMutation,
+        removeTrack: removeTrackMutation,
+        reorder: reorderMutation,
+      },
+    }),
+    [
+      addTracksMutation,
+      createMutation,
+      deleteMutation,
+      removeTrackMutation,
+      reorderMutation,
+      updateMutation,
+    ],
+  );
+};
+
+export default {
+  playlistKeys,
+  usePlaylistList,
+  usePlaylist,
+  usePlaylistMutations,
+};

--- a/frontend/src/features/playlists/pages/MyPlaylistsPage.jsx
+++ b/frontend/src/features/playlists/pages/MyPlaylistsPage.jsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import PlaylistCreateForm from '../components/PlaylistCreateForm.jsx';
+import PlaylistDetail from '../components/PlaylistDetail.jsx';
+import PlaylistList from '../components/PlaylistList.jsx';
+import {
+  PLAYLIST_DEFAULT_PAGE_SIZE,
+  usePlaylist,
+  usePlaylistList,
+  usePlaylistMutations,
+} from '../hooks/usePlaylists';
+import { useAuth } from '../../../shared/hooks/useAuth';
+
+const MyPlaylistsPage = () => {
+  const { user, loading } = useAuth();
+  const [page, setPage] = useState(1);
+  const perPage = PLAYLIST_DEFAULT_PAGE_SIZE;
+  const [selectedId, setSelectedId] = useState(null);
+  const [formError, setFormError] = useState('');
+
+  const listQuery = usePlaylistList({ page, perPage });
+  const playlists = listQuery.data?.items || [];
+  const pagination = listQuery.data?.pagination || {};
+
+  useEffect(() => {
+    if (!playlists.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !playlists.some((item) => item.id === selectedId)) {
+      setSelectedId(playlists[0].id);
+    }
+  }, [playlists, selectedId]);
+
+  const detailQuery = usePlaylist(selectedId);
+  const playlist = detailQuery.data;
+
+  const mutations = usePlaylistMutations();
+
+  const handleCreatePlaylist = async (payload) => {
+    try {
+      const response = await mutations.createPlaylist(payload);
+      const newId = response?.playlist?.id;
+      if (newId) {
+        setSelectedId(newId);
+      }
+      setFormError('');
+    } catch (error) {
+      console.error('Failed to create playlist', error);
+      setFormError('Unable to create playlist. Please try again.');
+    }
+  };
+
+  const handleDeletePlaylist = async (item) => {
+    try {
+      await mutations.deletePlaylist(item.id);
+      if (selectedId === item.id) {
+        setSelectedId(null);
+      }
+    } catch (error) {
+      console.error('Failed to delete playlist', error);
+    }
+  };
+
+  const handleAddTrack = async (track) => {
+    if (!selectedId) return;
+    await mutations.addTracks(selectedId, [track]);
+  };
+
+  const handleRemoveTrack = async (entry) => {
+    if (!selectedId) return;
+    await mutations.removeTrack(selectedId, entry.id);
+  };
+
+  const handleReorderTracks = async (order) => {
+    if (!selectedId) return;
+    await mutations.reorderTracks(selectedId, order);
+  };
+
+  const trackMutationPending = useMemo(
+    () =>
+      mutations.states.addTracks.isPending
+      || mutations.states.removeTrack.isPending
+      || mutations.states.reorder.isPending,
+    [
+      mutations.states.addTracks.isPending,
+      mutations.states.removeTrack.isPending,
+      mutations.states.reorder.isPending,
+    ],
+  );
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-brand-50 dark:bg-slate-950">
+        <p className="text-slate-600 dark:text-gray-300">Loading your playlists…</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-brand-50 dark:bg-slate-950">
+        <div className="rounded-2xl bg-white p-8 text-center shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:text-gray-200 dark:ring-gray-700">
+          <h1 className="mb-4 text-3xl font-semibold text-slate-900 dark:text-white">Sign in required</h1>
+          <p className="mb-6 text-slate-600 dark:text-gray-400">
+            Log in to create playlists and manage your favourite tracks.
+          </p>
+          <Link
+            to="/login"
+            className="rounded-full bg-brand-600 px-4 py-2 font-medium text-white transition hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400"
+          >
+            Go to login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-brand-50 py-8 dark:bg-slate-950">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 lg:flex-row">
+        <div className="lg:w-1/3 space-y-6">
+          <PlaylistCreateForm
+            onCreate={handleCreatePlaylist}
+            isSubmitting={mutations.states.create.isPending}
+          />
+          {formError && (
+            <p className="rounded-lg bg-brandError-100 p-3 text-sm text-brandError-700 dark:bg-brandError-900/40 dark:text-brandError-300">
+              {formError}
+            </p>
+          )}
+          <div className="rounded-2xl bg-white p-6 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:ring-gray-700">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Your playlists</h2>
+              <span className="text-sm text-slate-500 dark:text-gray-400">
+                Page {pagination.page || 1} / {pagination.pages || 1}
+              </span>
+            </div>
+            {listQuery.isLoading ? (
+              <p className="text-sm text-slate-600 dark:text-gray-300">Loading playlists…</p>
+            ) : (
+              <PlaylistList
+                playlists={playlists}
+                activePlaylistId={selectedId}
+                onSelect={(item) => setSelectedId(item.id)}
+                onDelete={handleDeletePlaylist}
+              />
+            )}
+            <div className="mt-4 flex items-center justify-between text-sm text-slate-600 dark:text-gray-400">
+              <button
+                type="button"
+                onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                disabled={!pagination.has_prev}
+                className={`rounded-full px-3 py-1 font-medium ${
+                  pagination.has_prev
+                    ? 'bg-brand-600 text-white hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400'
+                    : 'bg-slate-200 text-slate-500 dark:bg-gray-700 dark:text-gray-500'
+                }`}
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => setPage((prev) => (pagination.has_next ? prev + 1 : prev))}
+                disabled={!pagination.has_next}
+                className={`rounded-full px-3 py-1 font-medium ${
+                  pagination.has_next
+                    ? 'bg-brand-600 text-white hover:bg-brand-500 dark:bg-brandDark-500 dark:hover:bg-brandDark-400'
+                    : 'bg-slate-200 text-slate-500 dark:bg-gray-700 dark:text-gray-500'
+                }`}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:w-2/3">
+          {detailQuery.isLoading ? (
+            <div className="rounded-2xl bg-white p-6 text-center text-slate-600 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-700">
+              Loading playlist details…
+            </div>
+          ) : playlist ? (
+            <PlaylistDetail
+              playlist={playlist}
+              onAddTrack={handleAddTrack}
+              onRemoveTrack={handleRemoveTrack}
+              onReorderTracks={handleReorderTracks}
+              isMutating={trackMutationPending}
+            />
+          ) : (
+            <div className="rounded-2xl bg-white p-6 text-center text-slate-600 shadow ring-1 ring-brand-100 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-700">
+              Select a playlist from the list or create a new one to get started.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPlaylistsPage;

--- a/frontend/src/shared/components/AlbumCard.js
+++ b/frontend/src/shared/components/AlbumCard.js
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import FavoriteButton from '../../features/favorites/components/FavoriteButton.jsx';
+import FAVORITE_TOKENS from '../../theme/tokens';
 
 export const AlbumCardVariant = Object.freeze({
   DISCOVERY: 'discography',
@@ -19,6 +21,13 @@ const AlbumCard = ({ album, onDelete, onSelect, variant, isSelected, disabled })
   const subHeading = !isBestOf
     ? album?.artist || (album?.title && album.title !== displayName ? album.title : '')
     : '';
+  const favoriteMetadata = {
+    name: displayName,
+    subtitle: subHeading,
+    image_url: album?.image_url,
+    cover_url: album?.image_url,
+    spotify_url: album?.spotify_url,
+  };
 
   const handleCopyLink = useCallback(
     (event) => {
@@ -97,7 +106,7 @@ const AlbumCard = ({ album, onDelete, onSelect, variant, isSelected, disabled })
         isSelected ? 'border-4 border-brand-500' : 'border-2 border-transparent'
       }`}
     >
-      <div className="w-full aspect-square overflow-hidden">
+      <div className="relative w-full aspect-square overflow-hidden">
         <img
           src={album.image_url || FALLBACK_IMAGE}
           alt={`${displayName} Album Cover`}
@@ -106,6 +115,19 @@ const AlbumCard = ({ album, onDelete, onSelect, variant, isSelected, disabled })
           height="640"
           loading="lazy"
         />
+        <div className="absolute right-3 top-3 flex items-center gap-2">
+          {!isBestOf && (
+            <span className={`${FAVORITE_TOKENS.badgeClasses.base} ${FAVORITE_TOKENS.badgeClasses.active}`}>
+              Album
+            </span>
+          )}
+          <FavoriteButton
+            itemType="album"
+            itemId={String(album.id)}
+            metadata={favoriteMetadata}
+            size="sm"
+          />
+        </div>
       </div>
       <div className="p-4 text-center">
         <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-1 truncate">{displayName}</h3>

--- a/frontend/src/shared/components/Header.js
+++ b/frontend/src/shared/components/Header.js
@@ -25,7 +25,9 @@ const Header = () => {
     await logout();
   };
 
-  const links = NAV_LINKS.filter((link) => (user ? true : link.to !== '/download'));
+  const links = user
+    ? [...NAV_LINKS, { label: 'My Playlists', to: '/playlists' }, { label: 'Favourites', to: '/favorites' }]
+    : NAV_LINKS.filter((link) => link.to !== '/download');
 
   return (
   <header className="relative bg-white text-slate-900 shadow dark:bg-slate-950 dark:text-slate-100 border-b border-brand-100 dark:border-transparent">

--- a/frontend/src/shared/components/TrackTile.jsx
+++ b/frontend/src/shared/components/TrackTile.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import FavoriteButton from '../../features/favorites/components/FavoriteButton.jsx';
+import { formatDuration } from '../utils/formatting';
+
+const TrackTile = ({
+  track,
+  index,
+  renderActions,
+  className,
+  showDuration,
+  showFavorite,
+  favoriteItemType,
+  favoriteItemId,
+  favoriteMetadata,
+}) => {
+  if (!track) {
+    return null;
+  }
+
+  const artists = Array.isArray(track.artists)
+    ? track.artists
+    : typeof track.artists === 'string'
+      ? track.artists.split(',').map((part) => part.trim())
+      : [];
+  const trackNumber = track.track_number ?? index + 1;
+  const durationLabel = typeof track.duration_ms === 'number'
+    ? formatDuration(track.duration_ms)
+    : null;
+
+  const favoriteId = favoriteItemId
+    || track.spotify_id
+    || track.id
+    || track.uri
+    || track.url
+    || '';
+
+  const metadata = {
+    name: track.title,
+    subtitle: artists.join(', '),
+    cover_url: track.cover_url,
+    image_url: track.image_url,
+    spotify_url: track.spotify_url,
+    url: track.spotify_url || track.url,
+    ...favoriteMetadata,
+  };
+
+  return (
+    <li
+      className={`flex flex-col gap-3 rounded-lg bg-brand-50 p-4 shadow transition dark:bg-gray-800 sm:flex-row sm:items-center sm:justify-between ${className}`.trim()}
+    >
+      <div className="flex-1">
+        <p className="text-lg font-medium text-slate-900 dark:text-white">
+          {trackNumber}. {track.title}
+        </p>
+        {artists.length > 0 && (
+          <p className="text-sm text-slate-600 dark:text-gray-400">
+            {artists.join(', ')}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        {typeof renderActions === 'function' && renderActions({ track })}
+        {showFavorite && favoriteId && (
+          <FavoriteButton
+            itemType={favoriteItemType}
+            itemId={String(favoriteId)}
+            metadata={metadata}
+            size="sm"
+          />
+        )}
+        {showDuration && durationLabel && (
+          <span className="text-sm text-slate-600 dark:text-gray-400">
+            {durationLabel}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+};
+
+TrackTile.propTypes = {
+  track: PropTypes.shape({
+    spotify_id: PropTypes.string,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    uri: PropTypes.string,
+    url: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    artists: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.string,
+    ]),
+    duration_ms: PropTypes.number,
+    track_number: PropTypes.number,
+    cover_url: PropTypes.string,
+    image_url: PropTypes.string,
+    spotify_url: PropTypes.string,
+  }).isRequired,
+  index: PropTypes.number,
+  renderActions: PropTypes.func,
+  className: PropTypes.string,
+  showDuration: PropTypes.bool,
+  showFavorite: PropTypes.bool,
+  favoriteItemType: PropTypes.oneOf(['track', 'album', 'artist']),
+  favoriteItemId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  favoriteMetadata: PropTypes.object,
+};
+
+TrackTile.defaultProps = {
+  index: 0,
+  renderActions: undefined,
+  className: '',
+  showDuration: true,
+  showFavorite: true,
+  favoriteItemType: 'track',
+  favoriteItemId: undefined,
+  favoriteMetadata: undefined,
+};
+
+export default TrackTile;

--- a/frontend/src/theme/tokens.js
+++ b/frontend/src/theme/tokens.js
@@ -1,0 +1,20 @@
+export const FAVORITE_TOKENS = Object.freeze({
+  icon: Object.freeze({
+    active: '★',
+    inactive: '☆',
+  }),
+  iconClasses: Object.freeze({
+    base: 'transition-colors duration-150 ease-in-out text-2xl',
+    active: 'text-brandWarning-500 drop-shadow-sm dark:text-brandWarning-300',
+    inactive: 'text-slate-400 hover:text-brandWarning-400 dark:text-gray-500 dark:hover:text-brandWarning-400',
+  }),
+  badgeClasses: Object.freeze({
+    base: 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold uppercase tracking-wide',
+    active: 'bg-brandWarning-100 text-brandWarning-700 dark:bg-brandWarning-700/30 dark:text-brandWarning-300',
+    inactive: 'bg-slate-200 text-slate-600 dark:bg-gray-700 dark:text-gray-300',
+  }),
+});
+
+export const FAVORITE_TYPES = Object.freeze(['artist', 'album', 'track']);
+
+export default FAVORITE_TOKENS;

--- a/src/interfaces/http/routes/__init__.py
+++ b/src/interfaces/http/routes/__init__.py
@@ -8,6 +8,8 @@ from .progress import progress_bp
 from .config import config_bp
 from .auth import auth_bp
 from .compilation import compilation_bp
+from .playlist import playlist_bp
+from .favorites import favorite_bp
 
 __all__ = [
     "download_bp",
@@ -18,4 +20,6 @@ __all__ = [
     "config_bp",
     "auth_bp",
     "compilation_bp",
+    "playlist_bp",
+    "favorite_bp",
 ]

--- a/src/interfaces/http/routes/favorites.py
+++ b/src/interfaces/http/routes/favorites.py
@@ -1,0 +1,198 @@
+"""Favorite toggling and listings."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+from flask_login import current_user, login_required
+from sqlalchemy.exc import IntegrityError
+
+from src.database.db_manager import Favorite, db
+
+
+favorite_bp = Blueprint('favorite_bp', __name__, url_prefix='/api/favorites')
+
+VALID_FAVORITE_TYPES = {'artist', 'album', 'track'}
+
+
+def _serialize(favorite: Favorite) -> dict:
+    return favorite.to_dict()
+
+
+def _require_type_and_id(payload: dict) -> tuple[str, str] | tuple[None, None]:
+    item_type = (payload.get('item_type') or '').strip().lower()
+    item_id = (payload.get('item_id') or '').strip()
+    if item_type not in VALID_FAVORITE_TYPES or not item_id:
+        return None, None
+    return item_type, item_id
+
+
+@favorite_bp.route('', methods=['GET'])
+@login_required
+def list_favorites():
+    page = max(1, request.args.get('page', type=int) or 1)
+    per_page = request.args.get('per_page', type=int) or 20
+    per_page = max(1, min(100, per_page))
+    item_type = (request.args.get('type') or '').strip().lower()
+
+    query = Favorite.query.filter_by(user_id=current_user.id)
+    if item_type in VALID_FAVORITE_TYPES:
+        query = query.filter(Favorite.item_type == item_type)
+
+    pagination = query.order_by(Favorite.created_at.desc()).paginate(
+        page=page,
+        per_page=per_page,
+        error_out=False,
+    )
+
+    return (
+        jsonify(
+            {
+                'items': [_serialize(fav) for fav in pagination.items],
+                'pagination': {
+                    'page': pagination.page,
+                    'per_page': pagination.per_page,
+                    'pages': pagination.pages,
+                    'total': pagination.total,
+                    'has_next': pagination.has_next,
+                    'has_prev': pagination.has_prev,
+                },
+            }
+        ),
+        200,
+    )
+
+
+@favorite_bp.route('/summary', methods=['GET'])
+@login_required
+def favorites_summary():
+    summary = Favorite.summary_for_user(current_user.id)
+    for favorite_type in VALID_FAVORITE_TYPES:
+        summary.setdefault(favorite_type, 0)
+    return jsonify({'summary': summary}), 200
+
+
+@favorite_bp.route('/status', methods=['GET'])
+@login_required
+def favorite_status():
+    item_type = (request.args.get('item_type') or '').strip().lower()
+    item_id = (request.args.get('item_id') or '').strip()
+    if item_type not in VALID_FAVORITE_TYPES or not item_id:
+        return jsonify({'error': 'invalid_parameters'}), 400
+
+    favorite = Favorite.query.filter_by(
+        user_id=current_user.id,
+        item_type=item_type,
+        item_id=item_id,
+    ).first()
+
+    return (
+        jsonify(
+            {
+                'favorited': favorite is not None,
+                'favorite': _serialize(favorite) if favorite else None,
+            }
+        ),
+        200,
+    )
+
+
+@favorite_bp.route('/toggle', methods=['POST'])
+@login_required
+def toggle_favorite():
+    payload = request.get_json() or {}
+    item_type, item_id = _require_type_and_id(payload)
+    if not item_type:
+        return jsonify({'error': 'invalid_parameters'}), 400
+
+    metadata = payload.get('metadata') or {}
+    favorite = Favorite.query.filter_by(
+        user_id=current_user.id,
+        item_type=item_type,
+        item_id=item_id,
+    ).first()
+
+    if favorite:
+        db.session.delete(favorite)
+        db.session.commit()
+        summary = Favorite.summary_for_user(current_user.id)
+        for favorite_type in VALID_FAVORITE_TYPES:
+            summary.setdefault(favorite_type, 0)
+        return (
+            jsonify(
+                {
+                    'favorited': False,
+                    'favorite': None,
+                    'summary': summary,
+                }
+            ),
+            200,
+        )
+
+    favorite = Favorite(
+        user_id=current_user.id,
+        item_type=item_type,
+        item_id=item_id,
+        item_name=(metadata.get('name') or metadata.get('title') or item_id)[:255],
+        item_subtitle=(metadata.get('subtitle') or metadata.get('artist')),
+        item_image_url=metadata.get('image_url') or metadata.get('cover_url'),
+        item_url=metadata.get('url') or metadata.get('spotify_url'),
+    )
+    db.session.add(favorite)
+
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        favorite = Favorite.query.filter_by(
+            user_id=current_user.id,
+            item_type=item_type,
+            item_id=item_id,
+        ).first()
+        if favorite is None:
+            return jsonify({'error': 'unable_to_toggle'}), 409
+
+    summary = Favorite.summary_for_user(current_user.id)
+    for favorite_type in VALID_FAVORITE_TYPES:
+        summary.setdefault(favorite_type, 0)
+
+    return (
+        jsonify(
+            {
+                'favorited': True,
+                'favorite': _serialize(favorite),
+                'summary': summary,
+            }
+        ),
+        200,
+    )
+
+
+@favorite_bp.route('/<int:favorite_id>', methods=['DELETE'])
+@login_required
+def remove_favorite(favorite_id: int):
+    favorite = Favorite.query.filter_by(
+        id=favorite_id,
+        user_id=current_user.id,
+    ).first()
+    if favorite is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    db.session.delete(favorite)
+    db.session.commit()
+    summary = Favorite.summary_for_user(current_user.id)
+    for favorite_type in VALID_FAVORITE_TYPES:
+        summary.setdefault(favorite_type, 0)
+
+    return (
+        jsonify(
+            {
+                'favorited': False,
+                'favorite': None,
+                'summary': summary,
+            }
+        ),
+        200,
+    )
+
+
+__all__ = ['favorite_bp']

--- a/src/interfaces/http/routes/playlist.py
+++ b/src/interfaces/http/routes/playlist.py
@@ -1,0 +1,317 @@
+"""Playlist CRUD routes with ownership enforcement."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from flask import Blueprint, jsonify, request
+from flask_login import current_user, login_required
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from src.database.db_manager import (
+    db,
+    DownloadedTrack,
+    Playlist,
+    PlaylistTrack,
+)
+
+
+playlist_bp = Blueprint('playlist_bp', __name__, url_prefix='/api/playlists')
+
+
+def _serialize_playlist(playlist: Playlist, *, include_tracks: bool = True) -> dict:
+    return playlist.to_dict(include_tracks=include_tracks)
+
+
+def _owned_playlist(playlist_id: int) -> Playlist | None:
+    if not getattr(current_user, 'is_authenticated', False):
+        return None
+    return (
+        Playlist.query.options(
+            selectinload(Playlist.entries).selectinload(PlaylistTrack.track)
+        )
+        .filter_by(id=playlist_id, user_id=current_user.id)
+        .first()
+    )
+
+
+def _normalize_artists(value) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return [piece.strip() for piece in str(value).split(',') if piece.strip()]
+
+
+def _ensure_track(track_payload: dict, user_id: int) -> DownloadedTrack:
+    spotify_id = (track_payload.get('spotify_id') or track_payload.get('id') or '').strip()
+    if not spotify_id:
+        raise ValueError('Track spotify_id is required')
+
+    title = track_payload.get('title') or track_payload.get('name')
+    if not title:
+        raise ValueError('Track title is required')
+
+    artists = _normalize_artists(
+        track_payload.get('artists')
+        or track_payload.get('artist_names')
+        or track_payload.get('artist')
+    )
+
+    track = DownloadedTrack.query.filter_by(
+        spotify_id=spotify_id,
+        user_id=user_id,
+    ).first()
+
+    if track is None:
+        track = DownloadedTrack(
+            spotify_id=spotify_id,
+            spotify_url=track_payload.get('spotify_url') or track_payload.get('url'),
+            isrc=track_payload.get('isrc'),
+            title=title,
+            artists=artists,
+            album_name=track_payload.get('album_name') or track_payload.get('album'),
+            album_id=track_payload.get('album_id'),
+            album_artist=track_payload.get('album_artist'),
+            track_number=track_payload.get('track_number'),
+            disc_number=track_payload.get('disc_number'),
+            disc_count=track_payload.get('disc_count'),
+            tracks_count=track_payload.get('tracks_count'),
+            duration_ms=track_payload.get('duration_ms'),
+            explicit=bool(track_payload.get('explicit', False)),
+            popularity=track_payload.get('popularity'),
+            publisher=track_payload.get('publisher'),
+            year=track_payload.get('year'),
+            date=track_payload.get('date'),
+            genres=track_payload.get('genres'),
+            cover_url=track_payload.get('cover_url'),
+            local_path=track_payload.get('local_path'),
+            local_lyrics_path=track_payload.get('local_lyrics_path'),
+            user_id=user_id,
+        )
+        db.session.add(track)
+    else:
+        if artists and track.artists != artists:
+            track.artists = artists
+        if track.title != title:
+            track.title = title
+        if track.cover_url != track_payload.get('cover_url') and track_payload.get('cover_url'):
+            track.cover_url = track_payload.get('cover_url')
+        if track.spotify_url != track_payload.get('spotify_url') and track_payload.get('spotify_url'):
+            track.spotify_url = track_payload.get('spotify_url')
+
+    return track
+
+
+def _apply_tracks(playlist: Playlist, tracks: Iterable[dict]) -> None:
+    existing_spotify_ids = {
+        (entry.track.spotify_id if entry.track else None)
+        for entry in playlist.entries
+    }
+    next_position = max((entry.position for entry in playlist.entries), default=-1) + 1
+    for offset, payload in enumerate(tracks):
+        track = _ensure_track(payload, playlist.user_id)
+        if track.spotify_id in existing_spotify_ids:
+            continue
+        snapshot = track.to_dict()
+        snapshot['id'] = track.id
+        entry = PlaylistTrack(
+            playlist=playlist,
+            track=track,
+            position=next_position + offset,
+            track_snapshot=snapshot,
+        )
+        db.session.add(entry)
+        existing_spotify_ids.add(track.spotify_id)
+
+
+@playlist_bp.route('', methods=['GET'])
+@login_required
+def list_playlists():
+    page = max(1, request.args.get('page', type=int) or 1)
+    per_page = request.args.get('per_page', type=int) or 10
+    per_page = max(1, min(per_page, 50))
+
+    query = Playlist.query.filter_by(user_id=current_user.id).order_by(Playlist.updated_at.desc())
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+
+    return (
+        jsonify(
+            {
+                'items': [
+                    _serialize_playlist(playlist, include_tracks=False)
+                    for playlist in pagination.items
+                ],
+                'pagination': {
+                    'page': pagination.page,
+                    'per_page': pagination.per_page,
+                    'total': pagination.total,
+                    'pages': pagination.pages,
+                    'has_next': pagination.has_next,
+                    'has_prev': pagination.has_prev,
+                },
+            }
+        ),
+        200,
+    )
+
+
+@playlist_bp.route('', methods=['POST'])
+@login_required
+def create_playlist():
+    payload = request.get_json() or {}
+    name = (payload.get('name') or '').strip()
+    description = (payload.get('description') or '').strip() or None
+
+    if not name:
+        return jsonify({'error': 'name_required'}), 400
+
+    playlist = Playlist(name=name, description=description, user_id=current_user.id)
+    db.session.add(playlist)
+
+    tracks_payload = payload.get('tracks') or []
+    try:
+        _apply_tracks(playlist, tracks_payload)
+        db.session.commit()
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({'error': 'invalid_track', 'message': str(exc)}), 400
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({'error': 'duplicate_track'}), 409
+
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 201
+
+
+@playlist_bp.route('/<int:playlist_id>', methods=['GET'])
+@login_required
+def get_playlist(playlist_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 200
+
+
+@playlist_bp.route('/<int:playlist_id>', methods=['PUT'])
+@login_required
+def update_playlist(playlist_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    payload = request.get_json() or {}
+    if 'name' in payload:
+        name = (payload.get('name') or '').strip()
+        if not name:
+            return jsonify({'error': 'name_required'}), 400
+        playlist.name = name
+    if 'description' in payload:
+        playlist.description = (payload.get('description') or '').strip() or None
+
+    if 'tracks' in payload:
+        # Replace all tracks when explicit list provided
+        playlist.entries.clear()
+        db.session.flush()
+        try:
+            _apply_tracks(playlist, payload.get('tracks') or [])
+        except ValueError as exc:
+            db.session.rollback()
+            return jsonify({'error': 'invalid_track', 'message': str(exc)}), 400
+        except IntegrityError:
+            db.session.rollback()
+            return jsonify({'error': 'duplicate_track'}), 409
+
+    db.session.commit()
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 200
+
+
+@playlist_bp.route('/<int:playlist_id>', methods=['DELETE'])
+@login_required
+def delete_playlist(playlist_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    db.session.delete(playlist)
+    db.session.commit()
+    return jsonify({'status': 'deleted'}), 200
+
+
+@playlist_bp.route('/<int:playlist_id>/tracks', methods=['POST'])
+@login_required
+def add_tracks(playlist_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    payload = request.get_json() or {}
+    tracks_payload = payload.get('tracks')
+    if isinstance(tracks_payload, dict):
+        tracks_payload = [tracks_payload]
+    if not isinstance(tracks_payload, list):
+        return jsonify({'error': 'invalid_payload'}), 400
+
+    try:
+        _apply_tracks(playlist, tracks_payload)
+        db.session.commit()
+    except ValueError as exc:
+        db.session.rollback()
+        return jsonify({'error': 'invalid_track', 'message': str(exc)}), 400
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({'error': 'duplicate_track'}), 409
+
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 200
+
+
+@playlist_bp.route('/<int:playlist_id>/tracks/<int:entry_id>', methods=['DELETE'])
+@login_required
+def remove_track(playlist_id: int, entry_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    entry = next((item for item in playlist.entries if item.id == entry_id), None)
+    if entry is None:
+        return jsonify({'error': 'track_not_found'}), 404
+
+    db.session.delete(entry)
+    remaining = [e for e in playlist.entries if e.id != entry_id]
+    for index, item in enumerate(remaining):
+        item.position = index
+    db.session.commit()
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 200
+
+
+@playlist_bp.route('/<int:playlist_id>/tracks/reorder', methods=['PUT'])
+@login_required
+def reorder_tracks(playlist_id: int):
+    playlist = _owned_playlist(playlist_id)
+    if playlist is None:
+        return jsonify({'error': 'not_found'}), 404
+
+    payload = request.get_json() or {}
+    order = payload.get('order') or []
+    if not isinstance(order, list) or not order:
+        return jsonify({'error': 'invalid_payload'}), 400
+
+    entry_map = {entry.id: entry for entry in playlist.entries}
+    missing_ids = [entry_id for entry_id in order if entry_id not in entry_map]
+    if missing_ids:
+        return jsonify({'error': 'unknown_entries', 'entries': missing_ids}), 400
+
+    for position, entry_id in enumerate(order):
+        entry_map[entry_id].position = position
+
+    # Keep unspecified entries at the end preserving order
+    unspecified = [entry for entry in playlist.entries if entry.id not in order]
+    base = len(order)
+    for offset, entry in enumerate(sorted(unspecified, key=lambda e: e.position)):
+        entry.position = base + offset
+
+    db.session.commit()
+    return jsonify({'playlist': _serialize_playlist(playlist)}), 200
+
+
+__all__ = ['playlist_bp']


### PR DESCRIPTION
## Summary
- introduce playlist and favorite SQLAlchemy models plus secured REST endpoints
- add React Query-based playlists and favorites pages with optimistic updates and shared track tile
- standardize favorite icon tokens and apply across artist, album, and track surfaces

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e5aa2c11ec832bac513b8c545d4587